### PR TITLE
Lastmod quickfix

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -50,7 +50,7 @@
         {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
         {{- $cleanLinks := apply $links "chomp" "." -}}
         {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
-        &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}{{ $linksOutput }}
+        &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}&nbsp;{{ $linksOutput }}
       {{- end }}
     </h5>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,7 @@
       </svg>
       {{ $datestr | i18n "postedOnDate" }}
       {{ if ne $datestr $lastmodstr }}
-        &nbsp{{ $lastmodstr | i18n "lastModified" }}<br/>
+        &nbsp{{ $lastmodstr | i18n "lastModified" }}</h5><h5 class="text-sm flex items-center">
       {{ else }}
         &nbsp;&bull;&nbsp;
       {{ end }}


### PR DESCRIPTION
There is an ugly behaviour when lastmod-date is set in a post:
![before](https://user-images.githubusercontent.com/5812810/143735342-777badbf-34b3-4dd0-bad2-6858525f0e8e.png)

I am not sure, if this is the best solution, but the result is less ugly:
![after](https://user-images.githubusercontent.com/5812810/143735347-4e311eab-28b7-4429-8a9f-44ac01e48587.png)


