### PR TITLE
Ability to change the front page bundle

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -82,6 +82,9 @@ DefaultContentLanguageInSubdir = true
   # Reference: https://tailwindcss.com/docs/customizing-colors
   ascentColor = "bg-blue-100"
 
+  # The page bundle that is shown on the front page
+  frontBundle = "blog"
+
 [params.homepage.social]
   # Global params xommon for both languages
   title = "Follow me"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,12 +1,13 @@
 {{ define "main" }}
   {{- partial "intro.html" . -}}
+  {{ $frontBundle := .Site.Params.frontBundle | default "blog" }}
   <div class="container p-6 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-8">
-    {{ range first 6 (where .Site.RegularPages.ByDate.Reverse "Type" .Site.Params.frontBundle)  }}
+    {{ range first 6 (where .Site.RegularPages.ByDate.Reverse "Type" $frontBundle)  }}
       {{- partial "blog-card.html" . -}}
     {{ end }}
   </div>
 
-  {{ if gt (len (where .Site.RegularPages.ByDate.Reverse "Type" .Site.Params.frontBundle)) 6 }}
+  {{ if gt (len (where .Site.RegularPages.ByDate.Reverse "Type" $frontBundle)) 6 }}
   <div class="text-center mb-8">
     <a class="px-8 py-3 rounded transition-colors {{ .Site.Params.ascentColor | default "bg-pink-50" }}
       text-gray-500 hover:text-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,12 +1,11 @@
 {{ define "main" }}
   {{- partial "intro.html" . -}}
-  <div class="container p-6 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-8">
-    {{ range first 6 (where .Site.RegularPages.ByDate.Reverse "Type" "blog")  }}
+    {{ range first 6 (where .Site.RegularPages.ByDate.Reverse "Type" .Site.Params.frontBundle)  }}
       {{- partial "blog-card.html" . -}}
     {{ end }}
   </div>
 
-  {{ if gt (len (where .Site.RegularPages.ByDate.Reverse "Type" "blog")) 6 }}
+  {{ if gt (len (where .Site.RegularPages.ByDate.Reverse "Type" .Site.Params.frontBundle)) 6 }}
   <div class="text-center mb-8">
     <a class="px-8 py-3 rounded transition-colors {{ .Site.Params.ascentColor | default "bg-pink-50" }}
       text-gray-500 hover:text-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
   {{- partial "intro.html" . -}}
+  <div class="container p-6 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-8">
     {{ range first 6 (where .Site.RegularPages.ByDate.Reverse "Type" .Site.Params.frontBundle)  }}
       {{- partial "blog-card.html" . -}}
     {{ end }}


### PR DESCRIPTION
To have the bundle "blog" be hard coded for the front page seemed a bit unflexible. Now you can define it in the config.