### PR TITLE
Fix: Apply purgecss and safe the darkmode from it

### DIFF
--- a/assets/css/postcss.config.js
+++ b/assets/css/postcss.config.js
@@ -11,6 +11,7 @@ const purgecss = require("@fullhuman/postcss-purgecss")({
     let els = JSON.parse(content).htmlElements;
     return els.tags.concat(els.classes, els.ids);
   },
+  safelist: ["dark"],
 });
 
 module.exports = {
@@ -22,5 +23,6 @@ module.exports = {
     require("autoprefixer")({
       path: [themeDir],
     }),
+    purgecss
   ],
 };


### PR DESCRIPTION
I don't know how this ever worked.
The purgecss plugin was not applied. Maybe it was only to show how it could be done.
But maybe the bug was known, that it breaks the darkmode.

Nonetheless, it works now and brought my css from 7mb to 18kb :)