### PR TITLE
Fixed wrong alt variable on profile image

### DIFF
--- a/layouts/partials/intro.html
+++ b/layouts/partials/intro.html
@@ -4,6 +4,6 @@
       <h1 class="text-4xl font-bold mb-4">{{ .Site.Params.introTitle | safeHTML}}</h1>
       <p class="font-light text-lg">{{ .Site.Params.introSubtitle | safeHTML}}</p>
     </div>
-    <img class="rounded-lg shadow-sm" src="{{ .Site.Params.introPhoto }}" alt="{{ .Site.Params.Title }}" />
+    <img class="rounded-lg shadow-sm" src="{{ .Site.Params.introPhoto }}" alt="{{ .Site.Title }}" />
   </div>
 </section>


### PR DESCRIPTION
SEO check pointed out that the alt tag was missing on the profile image.
Turns out the wrong variable was used.