### PR TITLE
Improve the user experience with button

### DIFF
--- a/assets/css/paginator.css
+++ b/assets/css/paginator.css
@@ -2,7 +2,10 @@
   @apply inline-flex border rounded px-1 dark:border-gray-600;
 }
 .page-item {
-  @apply px-3 py-1 mx-0.5 my-1 cursor-pointer rounded hover:bg-gray-800 hover:text-white dark:hover:bg-gray-500 dark:hover:text-white;
+  @apply mx-0.5 my-1 cursor-pointer rounded hover:bg-gray-800 hover:text-white dark:hover:bg-gray-500 dark:hover:text-white;
+}
+a.page-link {
+  @apply px-3 py-1 block;
 }
 .page-item.active {
   @apply bg-gray-800 text-white dark:bg-gray-300 dark:text-gray-900;


### PR DESCRIPTION
I was going crazy when I clicked on the buttons but next to the link 🤪 !!! It's because the link is not the size of the link... .

To correct the problem I removed the `padding` from the `li` and placed the same `padding` on the link `a`. Finally I put the `a` in `block`.

In *pure CSS*, you have to remove the padding on .page-item and add this to page-link : 
```css
a.page-link{
display: block;
padding-left: .75rem;
padding-right: .75rem;
padding-top: .25rem;
padding-bottom: .25rem;
}
```

However, I saw that **Tailwind** was used on the theme, that's why I submit you this modification.

Before my correction : 
![before](https://user-images.githubusercontent.com/39600829/188924115-941b4b5a-1644-4f84-b382-1358101b3644.gif)

After my correction : 
![after](https://user-images.githubusercontent.com/39600829/188924145-494dafd9-e7bb-413b-9cab-052c37db953d.gif)


What do you think about it @apvarun  ?