### PR TITLE
GitHub href changed to .url

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -126,7 +126,7 @@
       {{ if eq .website "github" }}
       <li>
         <a
-          href="{{ .github }}"
+          href="{{ .url }}"
           target="_blank"
           rel="noopener"
           aria-label="GitHub"


### PR DESCRIPTION
There was a mistake in github url. Hypertext redirected always to `baseURL`.