### PR TITLE
Make comments box the same width as article text

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -65,9 +65,9 @@
     {{ end }}
 
     {{ .Content }}
+    {{- partial "comments.html" . -}}
   </article>
 
-  {{- partial "comments.html" . -}}
 
   {{- partial "social.html" . -}}
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,7 +19,7 @@
     <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
     {{ end }}
 
-    {{ if .Site.IsMultiLingual }}
+    {{ if hugo.IsMultilingual }}
     {{ if ge (len .Site.Languages) 3 }}
     <li class="relative cursor-pointer">
       <span class="language-switcher flex items-center gap-2">

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/apvarun/blist"
 demosite = "https://blist.vercel.app"
 tags = ["Hugo", "theme", "blog", "modern", "responsive"]
 features = ["clean", "gallery", "minimal", "minimalist", "mobile", "personal", "responsive", "simple", "tailwind", "blog", "white"]
-min_version = "0.110.0"
+min_version = "0.124.0"
 
 [author]
   name = "Varun A P"


### PR DESCRIPTION
This PR ensures that the Giscus comments box matches the width of the page content.  I think it looks much tidier: 

Currently:
<img width="1723" alt="image" src="https://user-images.githubusercontent.com/9963006/212190413-9baa4578-87ec-4a20-bd68-6e6041b5cf3b.png">

With this PR:
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/9963006/212190754-178964b7-e6c8-461a-80c7-01f531238534.png">

Interested to know what you think!