### PR TITLE
feat: add direction option to config.toml under [languages.x.params]

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -53,3 +53,7 @@ body {
     /* Safari, Android, iOS */ url("/fonts/inter-v3-latin-700.svg#Inter")
       format("svg"); /* Legacy iOS */
 }
+
+pre {
+  direction: ltr !important;
+}

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,7 @@ DefaultContentLanguageInSubdir = true
       introSubtitle = "26 y/o junior developer who enjoys social card games, blogging and painting"
       introPhoto = "/picture.jpg"
       logo = "/blist-logo.png"
+      direction = "ltr"
     [[languages.en.menu.main]]
         name = "Blog"
         url = "blog"
@@ -46,6 +47,7 @@ DefaultContentLanguageInSubdir = true
       introSubtitle = "26-jährige Junior-Entwicklerin, die Spaß an sozialen Kartenspielen, Bloggen und Malen hat"
       introPhoto = "/picture.jpg"
       logo = "/blist-logo-de.png"
+      direction = "ltr"
     [[languages.de.menu.main]]
         name = "Blog"
         url = "blog"
@@ -70,6 +72,7 @@ DefaultContentLanguageInSubdir = true
       introSubtitle = "Développeuse junior de 26 ans qui adore les jeux de société, le blogging et la peinture"
       introPhoto = "/picture.jpg"
       logo = "/blist-logo.png"
+      direction = "ltr"
     [[languages.fr.menu.main]]
         name = "Blog"
         url = "blog"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Lang }}" itemscope itemtype="http://schema.org/WebPage">
+<html dir="{{ if (isset .Site.Params "direction") }}{{ .Site.Params.direction }}{{ else }}ltr{{ end }}" lang="{{ .Lang }}" itemscope itemtype="http://schema.org/WebPage">
   {{- partial "head.html" . -}}
   <body class="dark:bg-gray-800 dark:text-white relative flex flex-col min-h-screen">
     {{- partial "header.html" . -}}


### PR DESCRIPTION
- add option `direction="rtl"` or `direction="ltr"` in config.toml under `[languages.x.params]` so that you can set the website direction based on the language used

- add `direction=""` option to exampleSite in `config.toml`

- add  css in the file `assets/css/site.css` so that `<pre>` tages always display ltr
becuase `<pre>` tags break when displayed rtl