### PR TITLE
add `hel="me"` in social.html template to verify mastodon profile

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -42,7 +42,7 @@
         <a
           href="{{ .url }}"
           target="_blank"
-          rel="noopener"
+          rel="noopener me"
           aria-label="Mastodon"
           class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
         >


### PR DESCRIPTION
to verify yourself as the owner of the links in your mastodon profile you have to add a link to your profile with `hel="me"`

so i added `hel="me"` in social.html to verify mastodon link