### PR TITLE
Update 404.html

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -19,7 +19,7 @@
   </svg>
   <div class="mt-16 z-10">
     <a class="px-6 py-4 rounded-lg bg-gray-100 text-gray-800 hover:text-gray-900 hover:bg-gray-200 transition-colors"
-      href="{{ .Site.BaseURL }}">Go to home</a>
+      href="{{ site.Home.Permalink }}">Go to home</a>
   </div>
 </section>
 


### PR DESCRIPTION
It is not recommended by Hugo Team to use `site.BaseURL` or `.Site.BaseURL` in templates. Use `absURL`, or `absLangURL` instead. `site.Home.Permalink` points to the respective homepage of a (multilingual) site.