### PR TITLE
Fix: raw html in header line

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -54,7 +54,7 @@
           {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
           {{- $cleanLinks := apply $links "chomp" "." -}}
           {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
-          &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}&nbsp;{{ $linksOutput }}
+          &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}&nbsp;{{ $linksOutput | safeHTML }}
         {{- end }}
       {{ end }}
     </h5>

--- a/layouts/partials/blog-card.html
+++ b/layouts/partials/blog-card.html
@@ -20,7 +20,7 @@
       {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
       {{- $cleanLinks := apply $links "chomp" "." -}}
       {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
-      {{ i18n "translationsLabel" }}{{ $linksOutput }}
+      {{ i18n "translationsLabel" }}{{ $linksOutput | safeHTML }}
     </div>
   {{- end }}
 {{ end }}


### PR DESCRIPTION
When running example site with latest hugo version v0.121.2, I see raw html output in the header line of many pages:

```
Posted on July 15, 2021  • 
1 minutes  •
149 words  • Other languages:  <a href="http://localhost:1313/de/page/about/" lang="de">Deutsch</a>
```

This PR fixes this issue.