### PR TITLE
Add safeHTML to the socials description

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -2,7 +2,7 @@
   <div class="container px-4 py-12 mx-auto max-w-4xl grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
     <div>
       <div class="text-2xl font-bold mb-2">{{ .Site.Params.homepage.social.title }}</div>
-      <p class="opacity-60">{{ .Site.Params.homepage.social.description }}</p>
+      <p class="opacity-60">{{ .Site.Params.homepage.social.description | safeHTML }}</p>
     </div>
 
     <ul class="flex justify-center gap-x-3 flex-wrap gap-y-2">


### PR DESCRIPTION
If for some reason you want to add few more new lines to the contact description now it renders text instead of using the html. With this addition we provide a bit more flexibility to add couple of new lines.

This contributes partially to #110 