### PR TITLE
Add physical address as an option in follow/contact section

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -169,6 +169,9 @@ DefaultContentLanguageInSubdir = true
   description = "I work on everything coding and tweet developer memes"
 
   [[params.homepage.social.icons]]
+    website = "address"
+    url = "John Doe<br/>SomeStreet 20<br/>SomeState"
+  [[params.homepage.social.icons]]
     website = "twitter"
     url = "https://twitter.com/"
   [[params.homepage.social.icons]]

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -3,6 +3,11 @@
     <div>
       <div class="text-2xl font-bold mb-2">{{ .Site.Params.homepage.social.title }}</div>
       <p class="opacity-60">{{ .Site.Params.homepage.social.description }}</p>
+      {{range .Site.Params.homepage.social.icons}}
+      {{ if eq .website "address" }}
+      <address class="opacity-60 text-sm pt-6">{{ .url | safeHTML }}</address>
+      {{ end }}
+      {{ end }}
     </div>
 
     <ul class="flex justify-center gap-x-3 flex-wrap gap-y-2">


### PR DESCRIPTION
If the theme is used by someone retro enough to post the address, then this option provides a generalized way to put a standard html address on the page. It might be a useful option in case someone wants to use it, but it is easily disabled by just commenting out the section.

I used the 6px padding and text small, so that it is a bit separated from the description text.