### PR TITLE
Replace deprecated IsMultiLingual to work with hugo 0.143.1+

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,7 +19,7 @@
     <li><a href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
     {{ end }}
 
-    {{ if .Site.IsMultiLingual }}
+    {{ if hugo.IsMultilingual }}
     {{ if ge (len .Site.Languages) 3 }}
     <li class="relative cursor-pointer">
       <span class="language-switcher flex items-center gap-2">


### PR DESCRIPTION
The deprecation error in hugo v0.143.1: `ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and subsequently removed. Use hugo.IsMultilingual instead.`