### PR TITLE
Example site: fix errors when previewing with latest hugo version 0.147.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then visit `http://localhost:1313/` in your browser to view the example site.
 1. Copy `package.json` and `package-lock.json` to the root folder of your website
 2. Run `npm install` to install required packages for theme
 3. Run `npm i -g postcss-cli` to use PostCSS with Hugo build
-4. Set `theme = 'blist'` in config.toml
+4. Set `theme = 'blist'` in hugo.toml
 5. Run `npm start` to start your local server
 
 Make sure to commit the above changes to your repository.
@@ -96,11 +96,11 @@ The following explains how to add content to your Hugo site. You can find sample
 
 ## Configure your site
 
-From `exampleSite/`, copy `config.toml` to the root folder of your Hugo site and change the fields as you like. Helpful comments are provided.
+From `exampleSite/`, copy `hugo.toml` to the root folder of your Hugo site and change the fields as you like. Helpful comments are provided.
 
 ### Menu
 
-Menu in Blist theme is pre-set to have all section names. You can include custom links in header using the `menu.main` option config.toml.
+Menu in Blist theme is pre-set to have all section names. You can include custom links in header using the `menu.main` option hugo.toml.
 
 ### Logo
 
@@ -141,7 +141,7 @@ Enable mathematical options: set `math: true` in your markdown frontmatter
 
 ### Google Analytics
 
-Set `googleAnalytics` in `config.toml` to activate Hugo's [internal Google Analytics template](https://gohugo.io/templates/internal/#google-analytics).
+Set `services.googleAnalytics.ID` in `hugo.toml` to activate Hugo's [embedded Google Analytics template](https://gohugo.io/templates/embedded/#google-analytics).
 
 ## Performance
 

--- a/exampleSite/content/de/blog/emoji-support.md
+++ b/exampleSite/content/de/blog/emoji-support.md
@@ -19,7 +19,7 @@ To enable emoji globally, set `enableEmoji` to `true` in your site's [configurat
 <p><span class="nowrap"><span class="emojify">🙈</span> <code>:see_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙉</span> <code>:hear_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙊</span> <code>:speak_no_evil:</code></span></p>
 <br>
 
-The [Emoji cheat sheet](http://www.emoji-cheat-sheet.com/) is a useful reference for emoji shorthand codes.
+The [Emoji cheat sheet](https://www.webfx.com/tools/emoji-cheat-sheet/) is a useful reference for emoji shorthand codes.
 
 ---
 

--- a/exampleSite/content/de/blog/rich-content.md
+++ b/exampleSite/content/de/blog/rich-content.md
@@ -19,9 +19,9 @@ Hugo wird mit mehreren [Built-in Shortcodes](https://gohugo.io/content-managemen
 
 ---
 
-## Tweet Shortcode
+## X Shortcode
 
-{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/en/blog/emoji-support.md
+++ b/exampleSite/content/en/blog/emoji-support.md
@@ -18,7 +18,7 @@ To enable emoji globally, set `enableEmoji` to `true` in your site's [configurat
 <p><span class="nowrap"><span class="emojify">🙈</span> <code>:see_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙉</span> <code>:hear_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙊</span> <code>:speak_no_evil:</code></span></p>
 <br>
 
-The [Emoji cheat sheet](http://www.emoji-cheat-sheet.com/) is a useful reference for emoji shorthand codes.
+The [Emoji cheat sheet](https://www.webfx.com/tools/emoji-cheat-sheet/) is a useful reference for emoji shorthand codes.
 
 ---
 

--- a/exampleSite/content/en/blog/rich-content.md
+++ b/exampleSite/content/en/blog/rich-content.md
@@ -19,9 +19,9 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Tweet Shortcode
+## X Shortcode
 
-{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -172,8 +172,8 @@ DefaultContentLanguageInSubdir = true
     website = "address"
     url = "John Doe<br/>SomeStreet 20<br/>SomeState"
   [[params.homepage.social.icons]]
-    website = "twitter"
-    url = "https://twitter.com/"
+    website = "x"
+    url = "https://x.com/"
   [[params.homepage.social.icons]]
     website = "linkedin"
     url = "https://linkedin.com/in/"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
     {{ end }}
   </div>
 
-  {{- partial "pagination.html" . -}}
+  {{- partial "paginate.html" . -}}
   
   {{- partial "social.html" . -}}
 {{ end }}

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.comments.system }}
 <div class="px-2 mb-2">
   {{ if eq .Site.Params.comments.system "disqus" }}
-  {{ template "_internal/disqus.html" . }}
+  {{ partial "disqus.html" . }}
   {{ else if eq .Site.Params.comments.system "giscus" }}
   <script src="https://giscus.app/client.js"
     data-repo="{{ .Site.Params.comments.repo }}"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,7 +19,7 @@
 {{- partial "search-ui.html" . -}}
 {{ end }}
 
-{{ template "_internal/google_analytics.html" . }}
+{{ partial "google_analytics.html" . }}
 
 {{ if ge (len .Site.Languages) 3 }}
 <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -56,9 +56,9 @@
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}
 
-  {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/twitter_cards.html" . }}
-  {{ template "_internal/schema.html" . }}
+  {{ partial "opengraph.html" . }}
+  {{ partial "twitter_cards.html" . }}
+  {{ partial "schema.html" . }}
 
   {{ if gt (len .Site.Languages) 1}}
   <meta name="lang" content="{{ .Site.Language }}" />

--- a/layouts/partials/paginate.html
+++ b/layouts/partials/paginate.html
@@ -1,3 +1,3 @@
 <div class="grid place-items-center mb-8">
-  {{ template "_internal/pagination.html" . }}
+  {{ partial "pagination.html" . }}
 </div>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -13,13 +13,13 @@
     <ul class="flex justify-center gap-x-3 flex-wrap gap-y-2">
       {{range .Site.Params.homepage.social.icons}}
 
-      {{ if eq .website "twitter" }}
+      {{ if eq .website "x" }}
       <li>
         <a
           href="{{ .url }}"
           target="_blank"
           rel="noopener"
-          aria-label="Twitter"
+          aria-label="X"
           class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
         >
           <svg


### PR DESCRIPTION
When previewing example site with latest hugo version 0.147.1, errors are thrown:

```
Error: html/template:_partials/pagination.html:2:14: no such template "_internal/pagination.html"
```

This PR fixes these errors.