### PR TITLE
Make number of items on the front page configurable

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -123,6 +123,9 @@ DefaultContentLanguageInSubdir = true
   # The page bundle that is shown on the front page
   frontBundle = "blog"
 
+  # Number of items on front page
+  frontNum = 8
+
   # Used to hide the post metadata such as posted date, reading time and word count
   # Can be used at site level or page level
   hideMeta = false

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,13 +1,14 @@
 {{ define "main" }}
   {{- partial "intro.html" . -}}
   {{ $frontBundle := .Site.Params.frontBundle | default "blog" }}
+  {{ $frontNum := .Site.Params.frontNum | default 6 }}
   <div class="container p-6 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-8">
-    {{ range first 6 (where .Site.RegularPages.ByDate.Reverse "Type" $frontBundle)  }}
+    {{ range first $frontNum (where .Site.RegularPages.ByDate.Reverse "Type" $frontBundle)  }}
       {{- partial "blog-card.html" . -}}
     {{ end }}
   </div>
 
-  {{ if gt (len (where .Site.RegularPages.ByDate.Reverse "Type" $frontBundle)) 6 }}
+  {{ if gt (len (where .Site.RegularPages.ByDate.Reverse "Type" $frontBundle)) $frontNum }}
   <div class="text-center mb-8">
     <a class="px-8 py-3 rounded transition-colors {{ .Site.Params.ascentColor | default "bg-pink-50" }}
       text-gray-500 hover:text-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:hover:text-white"


### PR DESCRIPTION
Currently the hardcoded limit of 6 was limiting factor for some more extensive usage of the template where you want to show more.

Since it is only used on front page and default remains 6 it is a backward compatible change